### PR TITLE
[mod] add option to suppress sentence-final newlines

### DIFF
--- a/xtsv/tsvhandler.py
+++ b/xtsv/tsvhandler.py
@@ -72,8 +72,9 @@ def process(stream, internal_app, conll_comments=False, default_pass_header=True
                 import sys
                 raise type(e)('In "{0}" at {1}: {2}'.format(track_stream['file_name'], curr_line, str(e))).\
                     with_traceback(sys.exc_info()[2])
+            
             # Finalizers can suppress sentence-final newlines in their output.
-            if not getattr(internal_app, 'suppress_newlines', False):
+            if getattr(internal_app, 'add_newline_after_sentence', True):
                 yield '\n'
 
             if sen_count % 1000 == 0:

--- a/xtsv/tsvhandler.py
+++ b/xtsv/tsvhandler.py
@@ -72,7 +72,9 @@ def process(stream, internal_app, conll_comments=False, default_pass_header=True
                 import sys
                 raise type(e)('In "{0}" at {1}: {2}'.format(track_stream['file_name'], curr_line, str(e))).\
                     with_traceback(sys.exc_info()[2])
-            yield '\n'
+            # Finalizers can suppress sentence-final newlines in their output.
+            if not getattr(internal_app, 'suppress_newlines', False):
+                yield '\n'
 
             if sen_count % 1000 == 0:
                 logger.info('{0}...'.format(sen_count))


### PR DESCRIPTION
The [documentation](https://github.com/nytud/xtsv/blob/e1663c2a1b6605bf31bab7a1a8d5e44e85c75c58/xtsv/tsvhandler.py#L31) claims that finalizer modules can have "free-format text as output". However, it does not seem to be possible to achieve this within xtsv since `tsvhandler.process` obligatorily inserts a newline at the end of each input sentence. So the output of any xtsv module cannot be completely free-format, but it contains at the very least one (possibly empty) output line for each input sentence.
For this reason I propose to add an option to suppress the insertion of this newline.

Use cases where this would be necessary:
- finalizers that detokenize tsv input, converting it into a readable output document,
- finalizers that **only** [output a summary of the input](https://github.com/nytud/xtsv/blob/e1663c2a1b6605bf31bab7a1a8d5e44e85c75c58/xtsv/tsvhandler.py#L88) and do not output each input sentence at all, such as those mentioned in section 5 of the [xtsv paper](https://aclanthology.org/2020.lrec-1.871.pdf),
- internal modules that want to remove individual input sentences from their output [for some reason or other](https://github.com/nytud/emtsv/issues/23).

NB: I don't insist on the double negation in the code. I think `suppress_newlines` with a default of `False` is much better from a semantic perspective than an `add_newlines` with a default of `True`, so the double negation is well worth it, but I could live with the latter as well, without the negation.