### PR TITLE
[add] integrity checks for columns

### DIFF
--- a/xtsv/tsvhandler.py
+++ b/xtsv/tsvhandler.py
@@ -75,15 +75,19 @@ def process(stream, internal_app, conll_comments=False, default_pass_header=True
             curr_line = track_stream['curr_line_number'] - (len(sen) + 1)
             try:
                 tokens = internal_app.process_sentence(sen, field_values)
-                for tok in tokens:
-                    curr_line += 1
-                    joined_tok = '{0}\n'.format('\t'.join(tok))
-                    if len(joined_tok.split('\t')) != len(field_names) // 2:
-                        raise ValueError(f'Number of fields expected: {len(field_names) // 2}.\n' +
-                                         'Number of fields in token: {0}.\n'.format(len(joined_tok.split('\t'))) +
-                                         'Invalid token:\n' + joined_tok)
-                    else:
-                        yield joined_tok
+                if getattr(internal_app, 'free_format_output', False):
+                    yield tokens
+                else:
+                    for tok in tokens:
+                        curr_line += 1
+                        joined_tok = '{0}\n'.format('\t'.join(tok))
+                        if len(joined_tok.split('\t')) != len(field_names) // 2:
+                            raise ValueError(f'Number of fields expected: {len(field_names) // 2}.\n' +
+                                             'Number of fields in token: {0}.\n'.
+                                                format(len(joined_tok.split('\t'))) +
+                                             'Invalid token:\n' + joined_tok)
+                        else:
+                            yield joined_tok
             except Exception as e:  # Catch every exception to add the file name and line number before reraise
                 import sys
                 raise type(e)('In "{0}" at {1}: {2}'.format(track_stream['file_name'], curr_line, str(e))).\

--- a/xtsv/tsvhandler.py
+++ b/xtsv/tsvhandler.py
@@ -14,6 +14,10 @@ def process_header(fields, source_fields, target_fields, track_stream):
         raise HeaderError('Input ({0}) does not have the required field names ({1}). '
                           'The following field names found: {2}'.
                           format(track_stream['file_name'], sorted(source_fields), fields))
+    duplicate_fields = set(fields).intersection(set(target_fields))
+    if duplicate_fields:
+        raise HeaderError('Input ({0}) already contains one or more target field names ({1}).'.
+                          format(track_stream['file_name'], sorted(duplicate_fields)))
     fields.extend(target_fields)                                    # Add target fields when apply (only for tagging)
     field_names = {name: i for i, name in enumerate(fields)}        # Decode field names
     field_names.update({i: name for i, name in enumerate(fields)})  # Both ways...
@@ -65,9 +69,21 @@ def process(stream, internal_app, conll_comments=False, default_pass_header=True
             sen_count += 1
             if len(comment) > 0:
                 yield comment
-            curr_line = track_stream['curr_line_number']
+
+            # Assuming that process_sentence() doesn't add tokens to or remove tokens from the sentence,
+            # otherwise these line numbers will be inaccurate.
+            curr_line = track_stream['curr_line_number'] - (len(sen) + 1)
             try:
-                yield from ('{0}\n'.format('\t'.join(tok)) for tok in internal_app.process_sentence(sen, field_values))
+                tokens = internal_app.process_sentence(sen, field_values)
+                for tok in tokens:
+                    curr_line += 1
+                    joined_tok = '{0}\n'.format('\t'.join(tok))
+                    if len(joined_tok.split('\t')) != len(field_names) // 2:
+                        raise ValueError(f'Number of fields expected: {len(field_names) // 2}.\n' +
+                                         'Number of fields in token: {0}.\n'.format(len(joined_tok.split('\t'))) +
+                                         'Invalid token:\n' + joined_tok)
+                    else:
+                        yield joined_tok
             except Exception as e:  # Catch every exception to add the file name and line number before reraise
                 import sys
                 raise type(e)('In "{0}" at {1}: {2}'.format(track_stream['file_name'], curr_line, str(e))).\


### PR DESCRIPTION
I propose adding two integrity checks to `tsvhandler.py` which would make debugging various errors in emtsv significantly easier.

1. **Check whether a target field of the current module is already present in the input.**
Duplicate column names in a module's output cause a problem in the next module downstream because they serve as keys in the `field_names` dict, cf. row 22: `field_names = {name: i for i, name in enumerate(fields)}`. Normally, after row 23 `field_names` contains exactly twice as many elements as the number of columns. This is not true if there are duplicate column names.
This problem might sound far-fetched, but it does happen, for example [if you tried to run emStanza according to the earlier official instructions](https://github.com/nytud/emtsv/pull/33) ("If emstanza-lem is run after emstanza-pos, those three columns are duplicated.").
**Because of this, a module should not be allowed to output a column with the same name as its input.**
This is solved in rows 17 to 20.

2. **Check whether the output line for a token contains exactly the right number of columns.**
If a module is buggy, it happens very often that some or all of its output tokens contain an incorrect number of columns, i.e. not exactly as many columns as the header. Ideally it is of course the modules' authors who should guarantee that their implementation of `process_sentence()` always outputs the correct number of columns, but [this is easier said than done](https://github.com/nytud/quntoken/issues/45). For this reason, `tsvhandler.process()` should double-check every token line that it yields whether it contains exactly as many columns as it should, except when the module explicitly specifies that it wants to return free-format output.
Note that just checking whether the length of the returned list of `process_sentence()` is equal to the expected number of columns is not sufficient, since the elements of this list might contain tab characters, like in the case of the bug I have just referred to.
The changes in rows 72 to 86 in commit https://github.com/nytud/xtsv/pull/8/commits/c13450c80c725c0c8f29762f49b96ac8c8d2ea8f handle this issue. I have adjusted the tracking of line numbers so that in case of an incorrect number of columns xtsv will report the actual line number of the offending token, not the number of the empty line after the sentence that the offending token appears in, like it normally does. A side effect of this change is that when an exception is raised by `process_sentence()`, what will be reported by `process()` is not the line number of the end of the **current** sentence, but of the line at the end of the **previous** sentence. Since this is exactly as **un**informative as the current exception handling messages, but at least provides an exact pointer to the problematic line for the `ValueError` raised when the column numbers are incorrect, this is still much better than leaving the tracking of lines as it is now.
The condition in lines 78-79 of commit https://github.com/nytud/xtsv/pull/8/commits/393896100e582267f301e63a7723b1dc3824db26 allows the module to skip this integrity check and return whatever it wants. This is meant for finalizers so that they can return free-format output.