### PR TITLE
semicolon invalidated if clause

### DIFF
--- a/xtsv/templates/layout.html
+++ b/xtsv/templates/layout.html
@@ -953,7 +953,7 @@
                         pointsToConsider.some(r => collector[l][oppositeDir].filter((d) => d !== levelD.head)
                             .includes(r)) ||
                         collector[l][oppositeDir].includes(parseInt(levelD.id))
-                        );
+                        )
                     {
                         finalLevel = l + 1;
                     }


### PR DESCRIPTION
Linting added semicolon by mistake after if clause here:

```
if (pointsToConsider.some(r => collector[l][levelD.direction].includes(r)) ||
                        pointsToConsider.some(r => collector[l][oppositeDir].filter((d) => d !== levelD.head)
                            .includes(r)) ||
                        collector[l][oppositeDir].includes(parseInt(levelD.id))
                        );
                    {
                        finalLevel = l + 1;
                    }
```